### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,8 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gnitko-andrei/devteam/security/code-scanning/1](https://github.com/gnitko-andrei/devteam/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the job or at the top level of the workflow. Since this workflow does not use the GITHUB_TOKEN for any write operations (e.g., no step pushes code or creates issues/releases), you can set it to the recommended minimal—`contents: read`—thus limiting the token to only read repository contents. This block should be added above the `jobs:` section (to apply to all jobs), or alternatively to the specific job if finer control is needed. Here, adding at the workflow root is preferred for clarity.

This fix involves editing .github/workflows/maven.yml and inserting:
```yaml
permissions:
  contents: read
```
right after the `name:` block and before `on:`.

No additional libraries or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
